### PR TITLE
Prompt for credentials if .auth not present

### DIFF
--- a/AquaMonitor.py
+++ b/AquaMonitor.py
@@ -7,6 +7,7 @@ import configparser
 import pyexpat
 import time
 import datetime
+import getpass
 
 host = 'http://www.aquamonitor.no/'
 aqua_site = 'AquaServices'
@@ -32,8 +33,10 @@ def login(username=None, password=None):
             config.read(".auth")
             username = config.get("Auth", "username")
             password = config.get("Auth", "password")
-        except Exception as ex:
-            raise Exception("Couldn't read username/password in file .auth")
+        except:
+            print("Couldn't read username/password from .auth file. Please enter your credentials.")
+            username = getpass.getpass(prompt="Username: ")
+            password = getpass.getpass(prompt="Password: ")
 
     loginurl = aqua_site + '/login'
 

--- a/AquaMonitor.py
+++ b/AquaMonitor.py
@@ -8,6 +8,7 @@ import pyexpat
 import time
 import datetime
 import getpass
+import os
 
 host = 'http://www.aquamonitor.no/'
 aqua_site = 'AquaServices'

--- a/AquaMonitor.py
+++ b/AquaMonitor.py
@@ -29,7 +29,7 @@ def requestService(url, params):
 
 def login(username=None, password=None):
     if username is None:
-        if os.path.is_file(".auth"):
+        if os.path.isfile(".auth"):
             config = configparser.RawConfigParser()
             try:
                 config.read(".auth")
@@ -38,6 +38,7 @@ def login(username=None, password=None):
             except Exception as ex:
                 raise Exception("Couldn't read username/password from .auth file.")
         else:
+            print("Please enter your credentials.")
             username = getpass.getpass(prompt="Username: ")
             password = getpass.getpass(prompt="Password: ")
 

--- a/AquaMonitor.py
+++ b/AquaMonitor.py
@@ -28,13 +28,15 @@ def requestService(url, params):
 
 def login(username=None, password=None):
     if username is None:
-        config = configparser.RawConfigParser()
-        try:
-            config.read(".auth")
-            username = config.get("Auth", "username")
-            password = config.get("Auth", "password")
-        except:
-            print("Couldn't read username/password from .auth file. Please enter your credentials.")
+        if os.path.is_file(".auth"):
+            config = configparser.RawConfigParser()
+            try:
+                config.read(".auth")
+                username = config.get("Auth", "username")
+                password = config.get("Auth", "password")
+            except Exception as ex:
+                raise Exception("Couldn't read username/password from .auth file.")
+        else:
             username = getpass.getpass(prompt="Username: ")
             password = getpass.getpass(prompt="Password: ")
 


### PR DESCRIPTION
Hi @roarbra,

A very minor suggestion for an update to the `login()` function: if reading the user's credentials from the `.auth` file fails, can we prompt the user to enter their credentials, instead of throwing an error? The code below just uses `getpass`, which is part of the Standard Library. Doing this makes the API a bit easier to use in e.g. a Jupyter environment, or anywhere where you don't want to store credentials in plain text in a `.auth` file. I don't think it should affect anything else?

Not a big deal either way, so just close and ignore if you don't like the suggestion :-)